### PR TITLE
Support subpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,5 +91,3 @@ sw.*
 
 # Vim swap files
 *.swp
-
-static/*

--- a/components/menu.vue
+++ b/components/menu.vue
@@ -43,7 +43,7 @@
         >
           <li
             v-for="subitem in item.children"
-            :key="subitem.hash"
+            :key="subitem.url ?? subitem.hash"
             class="w-full flex flex-col hover:text-sogblue-dark duration-200"
           >
             <nuxt-link
@@ -51,8 +51,7 @@
               :to="
                 localePath(
                   '/' +
-                    item.url +
-                    (subitem.hash !== '' ? '#' + subitem.hash : '')
+                    (subitem.url ? subitem.url : item.url + '#' + subitem.hash ?? '')
                 )
               "
               @click.native="menuItemExtended = ''"
@@ -62,7 +61,7 @@
             <ul class="ml-6">
               <li
                 v-for="subsubitem in subitem.children"
-                :key="subsubitem.url"
+                :key="subsubitem.url ?? subsubitem.hash"
                 class="flex text-black hover:text-sogblue-dark"
               >
                 <nuxt-link
@@ -70,8 +69,7 @@
                   :to="
                     localePath(
                       '/' +
-                        item.url +
-                        (subsubitem.hash !== '' ? '#' + subsubitem.hash : '')
+                        (subsubitem.url ? subsubitem.url : item.url + '#' + subsubitem.hash ?? '')
                     )
                   "
                   @click.native="menuItemExtended = ''"
@@ -94,7 +92,7 @@
             :class="selectLanguage ? 'text-sogblue-dark' : 'text-gray-600'"
             class="h-6 w-6 fill-current transition-colors duration-100"
           >
-            <use :href="localePath('/sprites/navSymbols.svg#language')" />
+            <use href="~/static/sprites/navSymbols.svg#language" />
           </svg>
         </div>
         <ul

--- a/components/menu.vue
+++ b/components/menu.vue
@@ -4,7 +4,7 @@
       <li class="flex-grow flex-shrink-0">
         <nuxt-link :to="localePath('/')">
           <img
-            src="~/static/Logo.png"
+            src="~/content/static/Logo.png"
             alt="Start"
             class="h-14 lg:h-20 xl:h-24"
           />
@@ -92,7 +92,7 @@
             :class="selectLanguage ? 'text-sogblue-dark' : 'text-gray-600'"
             class="h-6 w-6 fill-current transition-colors duration-100"
           >
-            <use href="~/static/sprites/navSymbols.svg#language" />
+            <use href="~/content/static/sprites/navSymbols.svg#language" />
           </svg>
         </div>
         <ul

--- a/components/mobileMenu.vue
+++ b/components/mobileMenu.vue
@@ -9,14 +9,14 @@
       <li class="flex items-center">
         <div class="mx-6" @click="selectLanguage = true">
           <svg class="h-6 w-6 fill-current text-gray-600">
-            <use :href="localePath('/sprites/navSymbols.svg#language')" />
+            <use href="~/static/sprites/navSymbols.svg#language" />
           </svg>
         </div>
       </li>
       <li class="flex items-center">
         <div @click="showMenu = true">
           <svg class="h-8 w-8 fill-current text-gray-700">
-            <use :href="localePath('/sprites/navSymbols.svg#burger')" />
+            <use href="~/static/sprites/navSymbols.svg#burger" />
           </svg>
         </div>
       </li>
@@ -42,7 +42,7 @@
             <li class="flex">
               <div @click="showMenu = false">
                 <svg class="h-8 w-8 fill-current text-gray-700">
-                  <use :href="localePath('/sprites/navSymbols.svg#cross')" />
+                  <use href="~/static/sprites/navSymbols.svg#cross" />
                 </svg>
               </div>
             </li>
@@ -83,15 +83,14 @@
           >
             <li
               v-for="subitem in item.children"
-              :key="subitem.hash"
+              :key="subitem.url ?? subitem.hash"
               class="ml-6 pt-2"
             >
               <nuxt-link
                 :to="
                   localePath(
                     '/' +
-                      item.url +
-                      (subitem.hash !== '' ? '#' + subitem.hash : '')
+                      (subitem.url ? subitem.url : item.url + '#' + subitem.hash ?? '')
                   )
                 "
                 @click.native="showMenu = false"
@@ -101,7 +100,7 @@
               <ul class="ml-6">
                 <li
                   v-for="subsubitem in subitem.children"
-                  :key="subsubitem.url"
+                  :key="subsubitem.url ?? subsubitem.hash"
                   class="flex"
                 >
                   <nuxt-link
@@ -109,8 +108,7 @@
                     :to="
                       localePath(
                         '/' +
-                          item.url +
-                          (subsubitem.hash !== '' ? '#' + subsubitem.hash : '')
+                        (subsubitem.url ? subsubitem.url : item.url + '#' + subsubitem.hash ?? '')
                       )
                     "
                     @click.native="showMenu = false"
@@ -142,7 +140,7 @@
             <li class="flex">
               <button @click="selectLanguage = false">
                 <svg class="h-8 w-8 fill-current text-gray-700">
-                  <use :href="localePath('/sprites/navSymbols.svg#cross')" />
+                  <use href="~/static/sprites/navSymbols.svg#cross" />
                 </svg>
               </button>
             </li>

--- a/components/mobileMenu.vue
+++ b/components/mobileMenu.vue
@@ -3,20 +3,20 @@
     <ul class="flex mb-8">
       <li class="flex-grow flex-shrink-0">
         <nuxt-link :to="localePath('/')">
-          <img src="~/static/Logo.png" alt="Start" class="h-14" />
+          <img src="~/content/static/Logo.png" alt="Start" class="h-14" />
         </nuxt-link>
       </li>
       <li class="flex items-center">
         <div class="mx-6" @click="selectLanguage = true">
           <svg class="h-6 w-6 fill-current text-gray-600">
-            <use href="~/static/sprites/navSymbols.svg#language" />
+            <use href="~/content/static/sprites/navSymbols.svg#language" />
           </svg>
         </div>
       </li>
       <li class="flex items-center">
         <div @click="showMenu = true">
           <svg class="h-8 w-8 fill-current text-gray-700">
-            <use href="~/static/sprites/navSymbols.svg#burger" />
+            <use href="~/content/static/sprites/navSymbols.svg#burger" />
           </svg>
         </div>
       </li>
@@ -36,13 +36,13 @@
                   menuItemExtended = ''
                 "
               >
-                <img src="~/static/Logo.png" alt="Start" class="h-14" />
+                <img src="~/content/static/Logo.png" alt="Start" class="h-14" />
               </nuxt-link>
             </li>
             <li class="flex">
               <div @click="showMenu = false">
                 <svg class="h-8 w-8 fill-current text-gray-700">
-                  <use href="~/static/sprites/navSymbols.svg#cross" />
+                  <use href="~/content/static/sprites/navSymbols.svg#cross" />
                 </svg>
               </div>
             </li>
@@ -134,13 +134,13 @@
                 :to="localePath('/')"
                 @click.native="selectLanguage = false"
               >
-                <img src="~/static/Logo.png" alt="Start" class="h-14" />
+                <img src="~/content/static/Logo.png" alt="Start" class="h-14" />
               </nuxt-link>
             </li>
             <li class="flex">
               <button @click="selectLanguage = false">
                 <svg class="h-8 w-8 fill-current text-gray-700">
-                  <use href="~/static/sprites/navSymbols.svg#cross" />
+                  <use href="~/content/static/sprites/navSymbols.svg#cross" />
                 </svg>
               </button>
             </li>

--- a/components/sogMap.vue
+++ b/components/sogMap.vue
@@ -38,7 +38,7 @@
             place.active ? 'fill-current' : 'fill-gray-400',
           ]"
         >
-          <use :href="localePath('/sprites/mapSymbols.svg#marker')" />
+          <use href="~/static/sprites/mapSymbols.svg#marker" />
         </svg>
         <div v-if="place.text_flow !== 'left'" class="-mt-3 sm:-mt-5 xl:-mt-7" :class="place.active ? '' : 'text-gray-400'">
           {{ place.name }}
@@ -89,7 +89,7 @@
           >
             <svg class="w-6 h-6 mr-2 fill-current">
               <use
-                :href="localePath('/sprites/socialSymbols.svg#' + link.type)"
+                :href="'~/static/sprites/socialSymbols.svg#' + link.type"
               />
             </svg>
             <div class="mr-6">
@@ -116,7 +116,7 @@
           <svg
             class="hidden md:block w-1/3 xl:w-1/5 ml-8 mt-3 stroke-current stroke-10 fill-none"
           >
-            <use :href="localePath('/sprites/mapSymbols.svg#arrow')" />
+            <use href="~/static/sprites/mapSymbols.svg#arrow" />
           </svg>
         </div>
         <div v-else class="text-gray-500 mb-20 mt-8 lg:mt-20 md:text-center">

--- a/components/sogMap.vue
+++ b/components/sogMap.vue
@@ -38,7 +38,7 @@
             place.active ? 'fill-current' : 'fill-gray-400',
           ]"
         >
-          <use href="~/static/sprites/mapSymbols.svg#marker" />
+          <use href="/sprites/mapSymbols.svg#marker" />
         </svg>
         <div v-if="place.text_flow !== 'left'" class="-mt-3 sm:-mt-5 xl:-mt-7" :class="place.active ? '' : 'text-gray-400'">
           {{ place.name }}
@@ -89,7 +89,7 @@
           >
             <svg class="w-6 h-6 mr-2 fill-current">
               <use
-                :href="'~/static/sprites/socialSymbols.svg#' + link.type"
+                :href="'/sprites/socialSymbols.svg#' + link.type"
               />
             </svg>
             <div class="mr-6">
@@ -116,7 +116,7 @@
           <svg
             class="hidden md:block w-1/3 xl:w-1/5 ml-8 mt-3 stroke-current stroke-10 fill-none"
           >
-            <use href="~/static/sprites/mapSymbols.svg#arrow" />
+            <use href="/sprites/mapSymbols.svg#arrow" />
           </svg>
         </div>
         <div v-else class="text-gray-500 mb-20 mt-8 lg:mt-20 md:text-center">

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -67,6 +67,10 @@ export default {
   // Modules (https://go.nuxtjs.dev/config-modules)
   modules: ['@nuxtjs/i18n', '@nuxt/content'],
 
+  dir: {
+    static: 'content/static',
+  },
+
   // Content module configuration (https://go.nuxtjs.dev/config-content)
   content: {},
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxt",
-    "build": "cp -r content/static/ static/ && nuxt build",
+    "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",

--- a/pages/index/_slug/_subslug.vue
+++ b/pages/index/_slug/_subslug.vue
@@ -5,12 +5,21 @@
 </template>
 
 <script>
+// This page only supports two levels content pages, e.g. /imprint or /our_work/sri_lanka
+//
+// Supporting arbitrary levels would require Unknown Dynamic Nested Routes
+// (https://v2.nuxt.com/docs/features/file-system-routing/#unknown-dynamic-nested-routes)
+// which are not supported by nuxt-i18n out of the box.
+//
+// If a page is not available that would not offer a switch to another locale.
 export default {
   name: 'SlugPage',
   async asyncData({ $content, params, app, error }) {
     try {
       const slug = params.slug || 'landing_page'
-      const page = await $content(`${app.i18n.locale}/${slug}`, 'index').fetch()
+      const page = params.subslug
+        ? await $content(`${app.i18n.locale}/${slug}/${params.subslug}`, 'index').fetch()
+        : await $content(`${app.i18n.locale}/${slug}`, 'index').fetch()
       return { page }
     } catch (err) {
       error({


### PR DESCRIPTION
This pull request adds support for subpages like `/our_work/sri_lanka`. See `/pages/_slug/_subslug.vue` for details why I implemented it this way.

Furthermore, I configured static files to use `content/static` as path so that these files don't have to be copied anymore which never worked out of the box. This fixes #14.